### PR TITLE
Update PNG behavior to reflect patch status

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -8,8 +8,6 @@ class App : public wxApp { public: virtual bool OnInit(); };
 
 wxIMPLEMENT_APP(App);
 
-bool patchFailed = false;
-
 bool App::OnInit() {
 	wxImage::AddHandler(new wxPNGHandler);
 
@@ -22,6 +20,8 @@ bool App::OnInit() {
 
 void MainWindow::ApplyPatches(wxCommandEvent& event) {
 	HWND win = FindWindowW(NULL, L"Mirror's Edge™ Catalyst");
+
+	bool patchFailed = false;
 
 	if (win) {
 		DWORD pid;

--- a/main.cpp
+++ b/main.cpp
@@ -1,10 +1,14 @@
 ﻿#include <wx/wx.h>
 
 #include "ui/ui.h"
+#include "ui/res/black.png.h"
+#include "ui/res/red.png.h"
 
 class App : public wxApp { public: virtual bool OnInit(); };
 
 wxIMPLEMENT_APP(App);
+
+bool patchFailed = false;
 
 bool App::OnInit() {
 	wxImage::AddHandler(new wxPNGHandler);
@@ -34,27 +38,36 @@ void MainWindow::ApplyPatches(wxCommandEvent& event) {
 				SetStatusText("Success!");
 			} else {
 				SetStatusText("ERROR: WriteProcessMemory failed.");
+				connectButton->SetBitmap(black_png_to_wx_bitmap());
+				patchFailed = true;
 			}
 
 			// Disable TLS in connect function
-			if (WriteProcessMemory(hproc, (LPVOID)0x142DBE9B0, &newData2, (DWORD)sizeof(newData2), NULL)) {
+			if (WriteProcessMemory(hproc, (LPVOID)0x142DBE9B0, &newData2, (DWORD)sizeof(newData2), NULL) && !patchFailed) {
 				SetStatusText("Success!");
 			} else {
 				SetStatusText("ERROR: WriteProcessMemory failed.");
+				connectButton->SetBitmap(black_png_to_wx_bitmap());
+				patchFailed = true;
 			}
 
 			// Bypass encryption of authenticated requests
-			if (WriteProcessMemory(hproc, (LPVOID)0x1439C0D81, &newData3, (DWORD)sizeof(newData3), NULL)) {
+			if (WriteProcessMemory(hproc, (LPVOID)0x1439C0D81, &newData3, (DWORD)sizeof(newData3), NULL) && !patchFailed) {
 				SetStatusText("Success!");
+				connectButton->SetBitmap(red_png_to_wx_bitmap());
 			} else {
 				SetStatusText("ERROR: WriteProcessMemory failed.");
+				connectButton->SetBitmap(black_png_to_wx_bitmap());
+				patchFailed = true;
 			}
 
 			CloseHandle(hproc);
 		} else {
 			SetStatusText("ERROR: Unable to open process.");
+			connectButton->SetBitmap(black_png_to_wx_bitmap());
 		}
 	} else {
 		SetStatusText("ERROR: Window not found.");
+		connectButton->SetBitmap(black_png_to_wx_bitmap());
 	}
 }

--- a/ui/res/black.png.h
+++ b/ui/res/black.png.h
@@ -122,7 +122,7 @@ static const unsigned char black_png[] =
 	0x60, 0x82, 
 };
 
-wxBitmap& black_png_to_wx_bitmap()
+inline wxBitmap& black_png_to_wx_bitmap()
 {
 	static wxMemoryInputStream memIStream( black_png, sizeof( black_png ) );
 	static wxImage image( memIStream, wxBITMAP_TYPE_PNG );

--- a/ui/res/red.png.h
+++ b/ui/res/red.png.h
@@ -144,7 +144,7 @@ static const unsigned char red_png[] =
 	0xAE, 0x42, 0x60, 0x82, 
 };
 
-wxBitmap& red_png_to_wx_bitmap()
+inline wxBitmap& red_png_to_wx_bitmap()
 {
 	static wxMemoryInputStream memIStream( red_png, sizeof( red_png ) );
 	static wxImage image( memIStream, wxBITMAP_TYPE_PNG );

--- a/ui/ui.cpp
+++ b/ui/ui.cpp
@@ -45,7 +45,6 @@ MainWindow::MainWindow( wxWindow* parent, wxWindowID id, const wxString& title, 
 	connectButton = new wxButton( bgPanel, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );
 
 	connectButton->SetBitmap( black_png_to_wx_bitmap() );
-	connectButton->SetBitmapFocus( red_png_to_wx_bitmap() );
 	connectButton->SetBitmapMargins( wxSize( 5,5 ) );
 	middleSizer->Add( connectButton, 0, wxALIGN_CENTER|wxALL, 5 );
 


### PR DESCRIPTION
This PR updates the bitmap behavior to reflect the patch status.

If the patch was successful, the program switches to the red png.
If the patch was unsuccessful, the program keeps the black png.